### PR TITLE
Removed a confusing CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ your computer you want to save your work. For me, it's the Freelance directory
 in my home folder:
 
 ```bash
-$ cd Freelance
 $ git clone https://github.com/nathandentzau/fsu-bootcamp-git.git
 ```
 


### PR DESCRIPTION
There was an initial cd Freelance line which didn't make sense
without a mkdir command. It has been removed to reduce confusion.
